### PR TITLE
Accept package as an argument to build-packages.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,9 @@ jobs:
           mkdir -p _output
           docker run -t --privileged \
           -v "$PWD":/repo \
-          -e PACKAGE \
           ghcr.io/t2linux/fedora-dev:latest \
-          /repo/build-packages.sh
-        env:
-          PACKAGE: ${{ matrix.package }}
+          /repo/build-packages.sh \
+          ${{ matrix.package }}
 
       - name: "Check Build Artifacts"
         run: |

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/bash
 source /repo/util.sh
 
-if [[ -z "$PACKAGE" ]]; then
-    PACKAGE=""
+if [[ -z "$1" ]]; then
+    package=""
     echo "Available packages: t2linux-config, t2linux-repo, t2linux-config, or kernel"
-    read -p "Name of package to build: " PACKAGE
+    read -p "Name of package to build: " package
+else
+    package="$1"
 fi
 
 cd /repo
 
-if [ "$PACKAGE" == "kernel" ]; then
+if [ "$package" == "kernel" ]; then
     /repo/kernel/kernel.sh
 fi
 
-cd /repo/$PACKAGE
-build_package $PACKAGE.spec
+cd /repo/$package
+build_package $package.spec


### PR DESCRIPTION
The build script will not build the package specified in `$PACKAGE`. The script will only build the first specified package, any other arguments will be ignored.